### PR TITLE
Add a pp for type t.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _build
+_opam

--- a/lib/c6502.ml
+++ b/lib/c6502.ml
@@ -37,6 +37,7 @@ module type CPU = sig
   val reset : t -> unit
   val nmi : t -> unit
   val print_state : t -> unit
+  val pp : Format.formatter -> t -> unit
 end
 
 module Utils = Utils
@@ -234,6 +235,20 @@ module Make (M : MemoryMap) = struct
       Format.printf "%a " pp_u8 (M.read st.mem Uint16.(pc + u16 i))
     done;
     Format.printf "\t\t A:%a X:%a Y:%a P:%a SP:%a CYC:%3d\n%!" pp_u8
+      (R.get st.reg `A) pp_u8 (R.get st.reg `X) pp_u8 (R.get st.reg `Y) pp_u8
+      (R.get st.reg `P) pp_u8 (R.get st.reg `S)
+      Stdlib.(st.cycle_count * 3 mod 341)
+
+  let pp fmt st =
+    let pc = PC.get st.pc in
+    let opcode = M.read st.mem pc in
+    let _, _, am = Decoding.decode opcode in
+    let size = Addressing.size am in
+    Format.fprintf fmt "%a  " pp_u16 pc;
+    for i = 0 to size - 1 do
+      Format.fprintf fmt "%a " pp_u8 (M.read st.mem Uint16.(pc + u16 i))
+    done;
+    Format.fprintf fmt "\t\t A:%a X:%a Y:%a P:%a SP:%a CYC:%3d\n%!" pp_u8
       (R.get st.reg `A) pp_u8 (R.get st.reg `X) pp_u8 (R.get st.reg `Y) pp_u8
       (R.get st.reg `P) pp_u8 (R.get st.reg `S)
       Stdlib.(st.cycle_count * 3 mod 341)

--- a/lib/c6502.ml
+++ b/lib/c6502.ml
@@ -225,20 +225,6 @@ module Make (M : MemoryMap) = struct
 
   let nmi st = NMI.pull st.nmi
 
-  let print_state st =
-    let pc = PC.get st.pc in
-    let opcode = M.read st.mem pc in
-    let _, _, am = Decoding.decode opcode in
-    let size = Addressing.size am in
-    Format.printf "%a  " pp_u16 pc;
-    for i = 0 to size - 1 do
-      Format.printf "%a " pp_u8 (M.read st.mem Uint16.(pc + u16 i))
-    done;
-    Format.printf "\t\t A:%a X:%a Y:%a P:%a SP:%a CYC:%3d\n%!" pp_u8
-      (R.get st.reg `A) pp_u8 (R.get st.reg `X) pp_u8 (R.get st.reg `Y) pp_u8
-      (R.get st.reg `P) pp_u8 (R.get st.reg `S)
-      Stdlib.(st.cycle_count * 3 mod 341)
-
   let pp fmt st =
     let pc = PC.get st.pc in
     let opcode = M.read st.mem pc in
@@ -252,4 +238,6 @@ module Make (M : MemoryMap) = struct
       (R.get st.reg `A) pp_u8 (R.get st.reg `X) pp_u8 (R.get st.reg `Y) pp_u8
       (R.get st.reg `P) pp_u8 (R.get st.reg `S)
       Stdlib.(st.cycle_count * 3 mod 341)
+
+  let print_state = pp Format.std_formatter
 end

--- a/lib/c6502.mli
+++ b/lib/c6502.mli
@@ -175,6 +175,9 @@ module type CPU = sig
   val print_state : t -> unit
   (** Print the content of the registers, PC, the cycle count and the current
         byte pointed by PC. *)
+
+  val pp : Format.formatter -> t -> unit
+  (** Fine-grained pretty-printer *)
 end
 
 module Utils = Utils


### PR DESCRIPTION
As discussed, adding a pp. This is duplicating code from the `print_state` function, definitely bad practice, so we could get rid of the old function if this is preferable to that.  